### PR TITLE
Kristofer, small fixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,5 +1,12 @@
 {
-    "configurations": [
+  "configurations": [
+    {
+      "name": "Launch Chrome, attach",
+      "port": 9222,
+      "request": "launch",
+      "type": "pwa-chrome",
+      "webRoot": "${workspaceFolder}"
+    },
     {
       "name": "Launch API",
       "type": "node-terminal",
@@ -11,7 +18,7 @@
       "name": "Launch FRONTEND",
       "type": "node-terminal",
       "request": "launch",
-      "command": "yarn workspace frontend start",
+      "command": "yarn workspace frontend start"
     }
   ]
 }

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -45,7 +45,13 @@ void (async (): Promise<void> => {
   if (process.env.NODE_ENV === 'development') {
     app.use(morgan('dev'));
     try {
-      await seedData();
+      const collections = await mongoose.connection.db
+        .listCollections()
+        .toArray();
+      if (collections.length === 0) {
+        // Only seed database if it is empty
+        await seedData();
+      }
     } catch (error) {
       logger.err('Could not connect to database.');
     }

--- a/packages/frontend/src/pages/Periods/Details/components/Details.tsx
+++ b/packages/frontend/src/pages/Periods/Details/components/Details.tsx
@@ -64,6 +64,9 @@ const PeriodDetails = (): JSX.Element | null => {
       },
       {
         position: 'top-center',
+        loading: {
+          duration: Infinity,
+        },
       }
     );
     promise.finally(() => setTimeout(() => history.go(0), 1000));

--- a/packages/frontend/src/pages/Periods/Details/components/ReceiverTable.tsx
+++ b/packages/frontend/src/pages/Periods/Details/components/ReceiverTable.tsx
@@ -6,54 +6,105 @@ import { useHistory, useParams } from 'react-router-dom';
 import { TableOptions, useSortBy, useTable } from 'react-table';
 import { useRecoilValue } from 'recoil';
 
-const ReceiverTable = (): JSX.Element => {
-  const history = useHistory();
+const ReceiverTable = (): JSX.Element | null => {
   const { periodId } = useParams<PeriodPageParams>();
   const isAdmin = useRecoilValue(HasRole(ROLE_ADMIN));
   const period = useRecoilValue(SinglePeriod(periodId));
-  const columns = React.useMemo(
-    () => [
-      {
-        Header: 'Receiver',
-        accessor: '_id',
-        Cell: (data: any): JSX.Element => (
-          <UserCell userId={data.row.original.userAccount.name} />
-        ),
-      },
-      {
-        Header: 'Number of praise',
-        className: 'text-center',
-        accessor: 'praiseCount',
-      },
-      {
-        Header: 'Total praise score',
-        className: 'text-center',
-        accessor: 'score',
-        sortType: 'basic',
-      },
-    ],
-    []
-  );
 
-  const options = {
-    columns,
-    data: period?.receivers ? period.receivers : [],
-    initialState: {
-      sortBy: [
+  const ReceiverTableInner = (): JSX.Element => {
+    const history = useHistory();
+
+    const columns = React.useMemo(
+      () => [
         {
-          id: period?.status === 'OPEN' ? 'praiseCount' : 'praiseScore',
-          desc: true,
+          Header: 'Receiver',
+          accessor: '_id',
+          Cell: (data: any): JSX.Element => (
+            <UserCell userId={data.row.original.userAccount.name} />
+          ),
+        },
+        {
+          Header: 'Number of praise',
+          className: 'text-center',
+          accessor: 'praiseCount',
+        },
+        {
+          Header: 'Total praise score',
+          className: 'text-center',
+          accessor: 'score',
+          sortType: 'basic',
         },
       ],
-    },
-  } as TableOptions<{}>;
-  const tableInstance = useTable(options, useSortBy);
+      []
+    );
 
-  const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
-    tableInstance;
+    const options = {
+      columns,
+      data: period?.receivers ? period.receivers : [],
+      initialState: {
+        sortBy: [
+          {
+            id: period?.status === 'OPEN' ? 'praiseCount' : 'praiseScore',
+            desc: true,
+          },
+        ],
+      },
+    } as TableOptions<{}>;
+    const tableInstance = useTable(options, useSortBy);
 
-  const handleClick = (data: any) => (): void => {
-    history.push(`/period/${periodId}/receiver/${data._id}`);
+    const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
+      tableInstance;
+
+    const handleClick = (data: any) => (): void => {
+      history.push(`/period/${periodId}/receiver/${data._id}`);
+    };
+
+    return (
+      <table
+        id="periods-table"
+        className="w-full table-auto"
+        {...getTableProps()}
+      >
+        <thead>
+          {headerGroups.map((headerGroup) => (
+            // eslint-disable-next-line react/jsx-key
+            <tr {...headerGroup.getHeaderGroupProps()}>
+              {headerGroup.headers.map((column) => (
+                // eslint-disable-next-line react/jsx-key
+                <th className="text-left" {...column.getHeaderProps()}>
+                  {column.render('Header')}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody {...getTableBodyProps()}>
+          {rows.map((row) => {
+            prepareRow(row);
+            return (
+              // eslint-disable-next-line react/jsx-key
+              <tr
+                className="cursor-pointer hover:bg-gray-100"
+                {...row.getRowProps()}
+                onClick={handleClick(row.original)}
+              >
+                {row.cells.map((cell) => {
+                  return (
+                    // eslint-disable-next-line react/jsx-key
+                    <td
+                      {...cell.getCellProps()}
+                      className={(cell.column as any).className}
+                    >
+                      {cell.render('Cell')}
+                    </td>
+                  );
+                })}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    );
   };
 
   if (!period) return <div>Period not found.</div>;
@@ -61,52 +112,9 @@ const ReceiverTable = (): JSX.Element => {
   if (period.status === 'QUANTIFY' && !isAdmin)
     return <div>Praise scores are not visible during quantification.</div>;
 
-  return (
-    <table
-      id="periods-table"
-      className="w-full table-auto"
-      {...getTableProps()}
-    >
-      <thead>
-        {headerGroups.map((headerGroup) => (
-          // eslint-disable-next-line react/jsx-key
-          <tr {...headerGroup.getHeaderGroupProps()}>
-            {headerGroup.headers.map((column) => (
-              // eslint-disable-next-line react/jsx-key
-              <th className="text-left" {...column.getHeaderProps()}>
-                {column.render('Header')}
-              </th>
-            ))}
-          </tr>
-        ))}
-      </thead>
-      <tbody {...getTableBodyProps()}>
-        {rows.map((row) => {
-          prepareRow(row);
-          return (
-            // eslint-disable-next-line react/jsx-key
-            <tr
-              className="cursor-pointer hover:bg-gray-100"
-              {...row.getRowProps()}
-              onClick={handleClick(row.original)}
-            >
-              {row.cells.map((cell) => {
-                return (
-                  // eslint-disable-next-line react/jsx-key
-                  <td
-                    {...cell.getCellProps()}
-                    className={(cell.column as any).className}
-                  >
-                    {cell.render('Cell')}
-                  </td>
-                );
-              })}
-            </tr>
-          );
-        })}
-      </tbody>
-    </table>
-  );
+  if (period.receivers) return <ReceiverTableInner />;
+
+  return null;
 };
 
 export default ReceiverTable;


### PR DESCRIPTION
Some minor fixes:
- Only seeds the database if it is completely empty,
- The "Assigning quantifiers" toast  is shown during the duration of assigning quantifiers.
- Added a new launch config that launches Chrome and attaches debugger - good if you use Brave or other browser as default
- `useTable` creates an infinite loop when table data is `[]` and sorting is used. Moved `useTable` to an inner component that renders only when `data != []`