### PR TITLE
Disallow active quantifier removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Disallow removal of users from the quantifier pool that are assigned as quantifiers in an ongoing quantification #150 #120
 - Refactoring of Login component to improve flow & reliability
 - Refactoring of recoil axios request wrappers -- extracted into axios instances defined in utils/api. Recoil wrappers are kept, but simply call the axios instance, to limit the scope of this refactor.
 - Remove recoil auth query wrappers -- moved into utils/auth

--- a/packages/api/src/period/types.ts
+++ b/packages/api/src/period/types.ts
@@ -88,3 +88,8 @@ export interface AssignQuantifiersDryRunOutput {
   poolAssignments: Quantifier[];
   poolDeficit: number;
 }
+
+export interface PeriodDateRange {
+  $gt: Date;
+  $lte: Date;
+}

--- a/packages/api/src/period/utils.ts
+++ b/packages/api/src/period/utils.ts
@@ -146,6 +146,11 @@ export const findPeriodDetailsDto = async (
   return response;
 };
 
+/**
+ * Find all Periods where status = QUANTIFY
+ * @param match Any paramaters to add to mongoose find query
+ * @returns
+ */
 export const findActivePeriods = async (
   match: object = {}
 ): Promise<PeriodDocument[]> => {
@@ -158,6 +163,11 @@ export const findActivePeriods = async (
   return periods;
 };
 
+/**
+ * Get mongoose query object representing date range of Period
+ * @param period
+ * @returns
+ */
 export const getPeriodDateRangeQuery = async (
   period: Period
 ): Promise<PeriodDateRange> => ({

--- a/packages/api/src/period/utils.ts
+++ b/packages/api/src/period/utils.ts
@@ -10,9 +10,11 @@ import {
 } from './transformers';
 import {
   Period,
+  PeriodDocument,
   PeriodDetailsDto,
   PeriodDetailsQuantifierDto,
   PeriodDetailsReceiver,
+  PeriodDateRange,
 } from './types';
 
 // Returns previous period end date or 1970-01-01 if no previous period
@@ -142,3 +144,22 @@ export const findPeriodDetailsDto = async (
   };
   return response;
 };
+
+export const findActivePeriods = async (
+  match: object = {}
+): Promise<PeriodDocument[]> => {
+  let periods: PeriodDocument[] | PeriodDocument = await PeriodModel.find({
+    endDate: { $lte: new Date() },
+    ...match,
+  });
+  if (!Array.isArray(periods)) periods = [periods];
+
+  return periods;
+};
+
+export const getPeriodDateRangeQuery = async (
+  period: Period
+): Promise<PeriodDateRange> => ({
+  $gt: await getPreviousPeriodEndDate(period),
+  $lte: period.endDate,
+});

--- a/packages/api/src/period/utils.ts
+++ b/packages/api/src/period/utils.ts
@@ -15,6 +15,7 @@ import {
   PeriodDetailsQuantifierDto,
   PeriodDetailsReceiver,
   PeriodDateRange,
+  PeriodStatusType,
 } from './types';
 
 // Returns previous period end date or 1970-01-01 if no previous period
@@ -149,7 +150,7 @@ export const findActivePeriods = async (
   match: object = {}
 ): Promise<PeriodDocument[]> => {
   let periods: PeriodDocument[] | PeriodDocument = await PeriodModel.find({
-    endDate: { $lte: new Date() },
+    status: PeriodStatusType.QUANTIFY,
     ...match,
   });
   if (!Array.isArray(periods)) periods = [periods];

--- a/packages/api/src/praise/utils.ts
+++ b/packages/api/src/praise/utils.ts
@@ -1,4 +1,5 @@
 import { BadRequestError } from '@error/errors';
+import { PeriodDateRange } from '@period/types';
 import { settingFloat } from '@shared/settings';
 import { PraiseModel } from './entities';
 import { praiseDocumentTransformer } from './transformers';
@@ -70,4 +71,21 @@ export const praiseWithScore = async (
   );
   praiseDetailsDto.score = await calculatePraiseScore(praise);
   return praiseDetailsDto;
+};
+
+export const countPraiseWithinDateRanges = async (
+  dateRanges: PeriodDateRange[],
+  match: object = {}
+): Promise<number> => {
+  const withinDateRangeQueries: { $createdAt: PeriodDateRange }[] =
+    dateRanges.map((q) => ({
+      $createdAt: q,
+    }));
+
+  const assignedPraiseCount: number = await PraiseModel.count({
+    $or: withinDateRangeQueries,
+    ...match,
+  });
+
+  return assignedPraiseCount;
 };

--- a/packages/api/src/praise/utils.ts
+++ b/packages/api/src/praise/utils.ts
@@ -73,6 +73,13 @@ export const praiseWithScore = async (
   return praiseDetailsDto;
 };
 
+
+/**
+ * Count all praise within given date ranges
+ * @param dateRanges
+ * @param match
+ * @returns
+ */
 export const countPraiseWithinDateRanges = async (
   dateRanges: PeriodDateRange[],
   match: object = {}


### PR DESCRIPTION
Quick fix for #120

**Overview**
- throw error when removing quantifier if they are assigned to any praise in period with `period.status = 'QUANTIFY'` 