### PR TITLE
Specify back link routes

### DIFF
--- a/packages/frontend/src/navigation/BackLink.tsx
+++ b/packages/frontend/src/navigation/BackLink.tsx
@@ -1,12 +1,16 @@
 import { useHistory } from 'react-router-dom';
 
-const BackLink = (): JSX.Element => {
+interface BackLinkProps {
+  to?: string;
+}
+const BackLink = ({ to }: BackLinkProps): JSX.Element => {
   const history = useHistory();
 
   return (
     <div
       onClick={(): void => {
-        history.goBack();
+        if (to) history.push(to);
+        else history.goBack();
       }}
       className="mb-2 text-sm cursor-pointer"
     >

--- a/packages/frontend/src/navigation/BackLink.tsx
+++ b/packages/frontend/src/navigation/BackLink.tsx
@@ -1,7 +1,7 @@
 import { useHistory } from 'react-router-dom';
 
 interface BackLinkProps {
-  to?: string;
+  to: string;
 }
 const BackLink = ({ to }: BackLinkProps): JSX.Element => {
   const history = useHistory();
@@ -9,8 +9,7 @@ const BackLink = ({ to }: BackLinkProps): JSX.Element => {
   return (
     <div
       onClick={(): void => {
-        if (to) history.push(to);
-        else history.goBack();
+        history.push(to);
       }}
       className="mb-2 text-sm cursor-pointer"
     >

--- a/packages/frontend/src/navigation/BackLink.tsx
+++ b/packages/frontend/src/navigation/BackLink.tsx
@@ -1,19 +1,17 @@
-import { useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 interface BackLinkProps {
   to: string;
 }
 const BackLink = ({ to }: BackLinkProps): JSX.Element => {
-  const history = useHistory();
-
   return (
-    <div
-      onClick={(): void => {
-        history.push(to);
-      }}
-      className="mb-2 text-sm cursor-pointer"
-    >
-      ← Back
+    <div className="mb-2">
+      <Link
+        to={to}
+        className="mb-2 text-sm cursor-pointer no-underline hover:underline"
+      >
+        ← Back
+      </Link>
     </div>
   );
 };

--- a/packages/frontend/src/pages/Periods/Create/PeriodCreatePage.tsx
+++ b/packages/frontend/src/pages/Periods/Create/PeriodCreatePage.tsx
@@ -139,7 +139,7 @@ const PeriodsCreatePage = (): JSX.Element => {
   return (
     <>
       <BreadCrumb name="Quantification periods" icon={faCalendarAlt} />
-      <BackLink />
+      <BackLink to="/periods" />
 
       <div className="w-2/3 praise-box">
         <h2 className="mb-2">Create period</h2>

--- a/packages/frontend/src/pages/Periods/Details/PeriodDetailsPage.tsx
+++ b/packages/frontend/src/pages/Periods/Details/PeriodDetailsPage.tsx
@@ -69,7 +69,7 @@ const PeriodDetailPage = (): JSX.Element => {
   return (
     <>
       <BreadCrumb name="Quantification periods" icon={faCalendarAlt} />
-      <BackLink />
+      <BackLink to="/periods" />
 
       <div className="w-2/3 praise-box ">
         <React.Suspense fallback="Loading…">

--- a/packages/frontend/src/pages/Periods/ReceiverSummary/ReceiverSummaryPage.tsx
+++ b/packages/frontend/src/pages/Periods/ReceiverSummary/ReceiverSummaryPage.tsx
@@ -37,10 +37,12 @@ const PeriodReceiverMessage = (): JSX.Element | null => {
 };
 
 const QuantSummaryPeriodReceiverPage = (): JSX.Element => {
+  const { periodId } = useParams<PeriodAndReceiverPageParams>();
+
   return (
     <>
       <BreadCrumb name={'Receiver summary for period'} icon={faCalendarAlt} />
-      <BackLink />
+      <BackLink to={`/period/${periodId}`} />
 
       <div className="w-2/3 praise-box">
         <React.Suspense fallback="Loading…">

--- a/packages/frontend/src/pages/PraiseDetails/PraiseDetailsPage.tsx
+++ b/packages/frontend/src/pages/PraiseDetails/PraiseDetailsPage.tsx
@@ -40,10 +40,18 @@ const PeriodReceiverMessage = (): JSX.Element | null => {
 };
 
 const QuantSummaryPraisePage = (): JSX.Element => {
+  const { praiseId } = useParams<PraisePageParams>();
+  const praise = useSinglePraiseQuery(praiseId);
+  const period = useRecoilValue(SinglePeriodByDate(praise?.createdAt));
+  const backLinkUrl =
+    period?._id && praise?.receiver._id
+      ? `/period/${period?._id}/receiver/${praise?.receiver._id}`
+      : '/';
+
   return (
     <>
       <BreadCrumb name={'Praise details'} icon={faCalendarAlt} />
-      <BackLink />
+      <BackLink to={backLinkUrl} />
 
       <div className="w-2/3 praise-box">
         <React.Suspense fallback="Loading…">

--- a/packages/frontend/src/pages/QuantifyPeriod/QuantifyPeriodPage.tsx
+++ b/packages/frontend/src/pages/QuantifyPeriod/QuantifyPeriodPage.tsx
@@ -36,10 +36,12 @@ const PeriodMessage = (): JSX.Element => {
 };
 
 const QuantifyPeriodPage = (): JSX.Element => {
+  const { periodId } = useParams<PeriodPageParams>();
+
   return (
     <>
       <BreadCrumb name="Quantify" icon={faCalendarAlt} />
-      <BackLink />
+      <BackLink to={`/period/${periodId}`} />
 
       <div className="w-2/3 praise-box">
         <React.Suspense fallback="Loading…">

--- a/packages/frontend/src/pages/QuantifyPeriodReceiver/QuantifyPeriodReceiverPage.tsx
+++ b/packages/frontend/src/pages/QuantifyPeriodReceiver/QuantifyPeriodReceiverPage.tsx
@@ -75,12 +75,14 @@ const PeriodMessage = (): JSX.Element | null => {
 };
 
 const QuantifyPeriodUserPage = (): JSX.Element => {
+  const { periodId } = useParams<PeriodPageParams>();
+
   return (
     <>
       <React.Suspense fallback="Loading…">
         <PeriodBreadCrumb />
       </React.Suspense>
-      <BackLink />
+      <BackLink to={`/quantify/period/${periodId}`} />
 
       <div className="w-2/3 praise-box">
         <React.Suspense fallback="Loading…">


### PR DESCRIPTION
Resolves https://github.com/commonsbuild/praise_frontend/issues/42

I implemented a different solution than specified in the above ticket. Rather than hide the BackLink component if the user was directed from an outside site based on browser history, the BackLink navigation path is specified explicitly. Lmk if the originally proposed solution is still preferred.

**Overview**
- Adds a "to" prop to the BackLink component
- Updates all uses of BackLink to specify 'to' prop