### PR TITLE
Improve refresh token error handling

### DIFF
--- a/packages/api/src/auth/controllers.ts
+++ b/packages/api/src/auth/controllers.ts
@@ -119,7 +119,7 @@ export const refresh = async (
 
   const user = await UserModel.findOne({ refreshToken });
   if (!user || !user._id || !user.ethereumAddress)
-    throw new NotFoundError('User');
+    throw new UnauthorizedError('Invalid refresh token');
 
   // confirm refreshToken provided is valid
   const jwt: TokenSet = jwtService.refreshJwt(refreshToken);

--- a/packages/frontend/src/utils/api.ts
+++ b/packages/frontend/src/utils/api.ts
@@ -28,7 +28,7 @@ const handleErrors = (err: AxiosError): void => {
   // Any HTTP Code which is not 2xx will be considered as error
   const statusCode = err?.response?.status;
 
-  if (!err?.response) {
+  if (err?.request && !err?.response) {
     toast.error('Server did not respond');
   } else if (statusCode === 404) {
     window.location.href = '/404';

--- a/packages/frontend/src/utils/api.ts
+++ b/packages/frontend/src/utils/api.ts
@@ -28,7 +28,7 @@ const handleErrors = (err: AxiosError): void => {
   // Any HTTP Code which is not 2xx will be considered as error
   const statusCode = err?.response?.status;
 
-  if (!statusCode) {
+  if (!err?.response) {
     toast.error('Server did not respond');
   } else if (statusCode === 404) {
     window.location.href = '/404';


### PR DESCRIPTION
Related to #165 

**Overview**
- modify `/auth/refresh` endpoint to throw a 401 if no user is found with matching refreshToken, rather than 404
- Reduce occurrences of 'Server did not respond' error toast by only displaying it if the request was successful, but there was no response.