### PR TITLE
Feat/203/praise forward

### DIFF
--- a/packages/api/src/praise/entities.ts
+++ b/packages/api/src/praise/entities.ts
@@ -41,6 +41,11 @@ const praiseSchema = new mongoose.Schema(
       required: true,
       index: true,
     },
+    forwarder: {
+      type: Schema.Types.ObjectId,
+      ref: 'UserAccount',
+      required: false,
+    },
   },
   {
     timestamps: true,

--- a/packages/api/src/praise/types.ts
+++ b/packages/api/src/praise/types.ts
@@ -14,6 +14,7 @@ export interface Praise {
   quantifications: Quantification[];
   giver: UserAccountDocument;
   receiver: UserAccountDocument;
+  forwarder?: UserAccountDocument;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -41,6 +42,7 @@ export interface PraiseDto {
   quantifications: QuantificationDto[];
   giver: UserAccountDto;
   receiver: UserAccountDto;
+  forwarder?: UserAccountDto;
   createdAt: string;
   updatedAt: string;
 }

--- a/packages/api/src/user/types.ts
+++ b/packages/api/src/user/types.ts
@@ -5,6 +5,7 @@ export enum UserRole {
   ADMIN = 'ADMIN',
   USER = 'USER',
   QUANTIFIER = 'QUANTIFIER',
+  FORWARDER = 'FORWARDER',
 }
 
 export interface User {

--- a/packages/discord-bot/src/commands/forward.ts
+++ b/packages/discord-bot/src/commands/forward.ts
@@ -1,0 +1,52 @@
+import { SlashCommandBuilder } from '@discordjs/builders';
+import { APIMessage } from 'discord-api-types/v9';
+import logger from 'jet-logger';
+import { forwardHandler } from '../handlers/forward';
+import { Command } from '../interfaces/Command';
+import { getMsgLink } from '../utils/format';
+
+export const forward: Command = {
+  data: new SlashCommandBuilder()
+    .setName('forward')
+    .setDescription('Forwards praise from one user to another user')
+    .addUserOption((option) =>
+      option
+        .setName('from')
+        .setDescription('The person from whom the praise is coming from')
+        .setRequired(true)
+    )
+    .addStringOption((option) =>
+      option
+        .setName('to')
+        .setDescription('Mention the users to whom this praise should go')
+        .setRequired(true)
+    )
+    .addStringOption((option) =>
+      option
+        .setName('reason')
+        .setDescription('The reason given for this Praise')
+        .setRequired(true)
+    ),
+
+  async execute(interaction) {
+    try {
+      if (!interaction.isCommand() || interaction.commandName !== 'forward')
+        return;
+
+      const msg = (await interaction.deferReply({
+        fetchReply: true,
+      })) as APIMessage | void;
+      if (msg === undefined) return;
+      await forwardHandler(
+        interaction,
+        getMsgLink(
+          interaction.guildId || '',
+          interaction.channelId || '',
+          msg.id
+        )
+      );
+    } catch (err) {
+      logger.err(err);
+    }
+  },
+};

--- a/packages/discord-bot/src/handlers/forward.ts
+++ b/packages/discord-bot/src/handlers/forward.ts
@@ -1,0 +1,177 @@
+import { PraiseModel } from 'api/dist/praise/entities';
+import {
+  CommandInteraction,
+  Message,
+  GuildMember,
+  MessageEmbed,
+} from 'discord.js';
+import { UserModel } from 'api/dist/user/entities';
+import logger from 'jet-logger';
+import { getSetting } from '../utils/getSettings';
+import { getUserAccount } from '../utils/getUserAccount';
+import { UserRole } from 'api/dist/user/types';
+import {
+  dmError,
+  invalidReceiverError,
+  missingReasonError,
+  notActivatedDM,
+  notActivatedError,
+  praiseSuccess,
+  praiseSuccessDM,
+  roleMentionWarning,
+  undefinedReceiverWarning,
+} from '../utils/praiseEmbeds';
+
+export const forwardHandler = async (
+  interaction: CommandInteraction,
+  responseUrl: string
+): Promise<void> => {
+  const { guild, channel, member } = interaction;
+
+  if (!guild || !member) {
+    await interaction.editReply(await dmError());
+    return;
+  }
+
+  const forwarderAccount = await getUserAccount(member as GuildMember);
+  if (!forwarderAccount.user) {
+    await interaction.editReply(await notActivatedError());
+    return;
+  }
+  const forwarderUser = await UserModel.findOne({ _id: forwarderAccount.user });
+  if (!forwarderUser?.roles.includes(UserRole.FORWARDER)) {
+    await interaction.editReply(
+      "You don't have the permission to use this command."
+    );
+    return;
+  }
+
+  const praiseGiver = interaction.options.getMember('from') as GuildMember;
+
+  const praiseGiverRoleID = await getSetting('PRAISE_GIVER_ROLE_ID');
+  const praiseGiverRole = guild.roles.cache.find(
+    (r) => r.id === praiseGiverRoleID
+  );
+
+  if (
+    praiseGiverRole &&
+    !praiseGiver?.roles.cache.find((r) => r.id === praiseGiverRole?.id)
+  ) {
+    await interaction.editReply({
+      embeds: [
+        new MessageEmbed()
+          .setDescription(
+            `**❌ praiseGiver does not have \`${praiseGiverRole.name}\` role**\nPraise can only be dished by or forwarded from members with the <@&${praiseGiverRole.id}> role. Contact the praiseGiver, so that they can attend an onboarding-call, or ask a steward or guide for an Intro to Praise.`
+          )
+          .setColor('#f00'),
+      ],
+    });
+
+    return;
+  }
+  const giverAccount = await getUserAccount(praiseGiver);
+
+  const receivers = interaction.options.getString('to');
+  const reason = interaction.options.getString('reason');
+
+  const receiverData = {
+    validReceiverIds: receivers?.match(/<@!([0-9]+)>/g),
+    undefinedReceivers: receivers?.match(/@([a-z0-9]+)/gi),
+    roleMentions: receivers?.match(/<@&([0-9]+)>/g),
+  };
+
+  if (
+    !receivers ||
+    receivers.length === 0 ||
+    !receiverData.validReceiverIds ||
+    receiverData.validReceiverIds?.length === 0
+  ) {
+    await interaction.editReply(await invalidReceiverError());
+    return;
+  }
+
+  if (!reason || reason.length === 0) {
+    await interaction.editReply(await missingReasonError());
+    return;
+  }
+
+  if (!giverAccount.user) {
+    await interaction.editReply(
+      `**❌ praiseGiver Account Not Activated**\n<@!${giverAccount.accountId}>'s account is not activated in the praise system. Unactivated accounts can not praise users. The praiseGiver would have to use the \`/activate\` command to activate their praise account and to link their eth address.`
+    );
+    return;
+  }
+
+  const praised: string[] = [];
+  const receiverIds = receiverData.validReceiverIds.map((id) =>
+    id.substr(3, id.length - 4)
+  );
+  const Receivers = (await guild.members.fetch({ user: receiverIds })).map(
+    (u) => u
+  );
+
+  const guildChannel = await guild.channels.fetch(channel?.id || '');
+
+  for (const receiver of Receivers) {
+    const receiverAccount = await getUserAccount(receiver);
+
+    if (!receiverAccount.user) {
+      try {
+        await receiver.send({ embeds: [await notActivatedDM(responseUrl)] });
+      } catch (err) {
+        logger.warn(
+          `Can't DM user - ${receiverAccount.name} [${receiverAccount.accountId}]`
+        );
+      }
+    }
+    const praiseObj = await PraiseModel.create({
+      reason: reason,
+      giver: giverAccount._id,
+      forwarder: forwarderAccount._id,
+      sourceId: `DISCORD:${guild.id}:${interaction.channelId}`,
+      sourceName: `DISCORD:${encodeURIComponent(
+        guild.name
+      )}:${encodeURIComponent(guildChannel?.name || '')}`,
+      receiver: receiverAccount._id,
+    });
+    if (praiseObj) {
+      try {
+        await receiver.send({ embeds: [await praiseSuccessDM(responseUrl)] });
+      } catch (err) {
+        logger.warn(
+          `Can't DM user - ${receiverAccount.name} [${receiverAccount.accountId}]`
+        );
+      }
+      praised.push(receiverAccount.accountId);
+    } else {
+      logger.err(
+        `Praise not registered for [${giverAccount.accountId}] -> [${receiverAccount.accountId}] for [${reason}]`
+      );
+    }
+  }
+
+  const msg = (await interaction.editReply(
+    `✅  Forward praise from <@!${praiseGiver.user.id}> to ${praised
+      .map((id) => `<@!${id}>`)
+      .join(', ')} for ${reason}`
+  )) as Message;
+
+  if (receiverData.undefinedReceivers) {
+    await msg.reply(
+      await undefinedReceiverWarning(
+        receiverData.undefinedReceivers.join(', '),
+        praiseGiver.user
+      )
+    );
+  }
+  if (receiverData.roleMentions) {
+    await msg.reply(
+      await roleMentionWarning(
+        receiverData.roleMentions.join(', '),
+        praiseGiver.user
+      )
+    );
+  }
+
+  return;
+};

--- a/packages/discord-bot/src/utils/getUserAccount.ts
+++ b/packages/discord-bot/src/utils/getUserAccount.ts
@@ -1,0 +1,20 @@
+import { UserAccountModel } from 'api/dist/useraccount/entities';
+import { UserAccount, UserAccountDocument } from 'api/src/useraccount/types';
+import { GuildMember } from 'discord.js';
+export const getUserAccount = async (
+  member: GuildMember
+): Promise<UserAccountDocument> => {
+  const ua = {
+    accountId: member.user.id,
+    name: member.user.username + '#' + member.user.discriminator,
+    avatarId: member.user.avatar,
+    platform: 'DISCORD',
+  } as UserAccount;
+
+  const userAccount = await UserAccountModel.findOneAndUpdate(
+    { accountId: ua.accountId },
+    ua,
+    { upsert: true, new: true }
+  );
+  return userAccount;
+};

--- a/packages/discord-bot/src/utils/praiseEmbeds.ts
+++ b/packages/discord-bot/src/utils/praiseEmbeds.ts
@@ -8,7 +8,7 @@ export const praiseSuccess = async (
   const msg = await getSetting('PRAISE_SUCCESS_MESSAGE');
   if (msg && typeof msg === 'string') {
     return msg
-      ?.replace('{receivers}', `${praised.join(', ')}`)
+      ?.replace('{@receivers}', `${praised.join(', ')}`)
       .replace('{reason}', reason);
   } else {
     return 'PRAISE SUCCESSFUL (message not set)';


### PR DESCRIPTION
## Description
This PR add the praise forward functionality(praise-on-behalf)
The PR only changes the discord bot and the backend. (The frontend would need tweaks to visually distinguish between these and normal praises)

Also, a new UserRole -> "FORWARDER" has been added (temporarily?). Currently, this requires manually adding the role via mongosh
