### PR TITLE
Fix/assign quantifiers only once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Modify settings architecture so Periods have their own unique settings. New periods are created with the "global" settings as default values. #138 #116
+- Verify no quantifiers have been assigned in period before assigning
 
 ## [0.2.0] - 2022-03-31
 

--- a/packages/api/src/period/controllers.ts
+++ b/packages/api/src/period/controllers.ts
@@ -53,6 +53,7 @@ import {
   findPeriodDetailsDto,
   getPeriodDateRangeQuery,
   getPreviousPeriodEndDate,
+  verifyAnyPraiseAssigned,
 } from './utils';
 import { PeriodModel } from './entities';
 import { periodDocumentTransformer } from './transformers';
@@ -410,6 +411,12 @@ export const assignQuantifiers = async (
   if (period.status !== 'OPEN')
     throw new BadRequestError(
       'Quantifiers can only be assigned on OPEN periods.'
+    );
+
+  const anyPraiseAssigned = await verifyAnyPraiseAssigned(period);
+  if (anyPraiseAssigned)
+    throw new BadRequestError(
+      'Some praise has already been assigned for this period'
     );
 
   const assignedQuantifiers: AssignQuantifiersDryRunOutput =


### PR DESCRIPTION
Short-term workaround to reduce risk of https://github.com/commonsbuild/praise_frontend/issues/101
Resolves #101  -- I created a new ticket #223 to consider more "ideal" solutions.

**Overview**
- (merged `feat/per_period_settings` to avoid a tricky merge later)
- created utilily function `verifyAnyPraiseAssigned()` to check if any praise within a given period has already been assigned to quantifiers
- modify period controller `assignQuantifiers` to throw an error if any praise has been assigned for the period.