### PR TITLE
Fix/ validation failure during assign quantifiers

### DIFF
--- a/packages/api/src/period/controllers.ts
+++ b/packages/api/src/period/controllers.ts
@@ -143,7 +143,8 @@ export const update = async (
   }
 
   if (endDate) {
-    if (!isPeriodLatest(period))
+    const latest = await isPeriodLatest(period);
+    if (!latest)
       throw new BadRequestError('Date change only allowed on last period.');
 
     if (period.status !== PeriodStatusType.OPEN)
@@ -461,7 +462,10 @@ export const assignQuantifiers = async (
   );
 
   await PraiseModel.bulkWrite(bulkQueries);
-  await PeriodModel.updateOne({_id: period._id}, {$set: {status: PeriodStatusType.QUANTIFY}});
+  await PeriodModel.updateOne(
+    { _id: period._id },
+    { $set: { status: PeriodStatusType.QUANTIFY } }
+  );
 
   const periodDetailsDto = await findPeriodDetailsDto(periodId);
   res.status(StatusCodes.OK).json(periodDetailsDto);

--- a/packages/api/src/period/controllers.ts
+++ b/packages/api/src/period/controllers.ts
@@ -175,9 +175,6 @@ export const close = async (
   const period = await PeriodModel.findById(req.params.periodId);
   if (!period) throw new NotFoundError('Period');
 
-  if (period.status !== PeriodStatusType.QUANTIFY)
-    throw Error('Only Periods with status QUANTIFY can be closed');
-
   period.status = PeriodStatusType.CLOSED;
   await period.save();
 

--- a/packages/api/src/period/controllers.ts
+++ b/packages/api/src/period/controllers.ts
@@ -451,9 +451,7 @@ export const assignQuantifiers = async (
   );
 
   await PraiseModel.bulkWrite(bulkQueries);
-
-  period.status = PeriodStatusType.QUANTIFY;
-  await period.save();
+  await PeriodModel.updateOne({_id: period._id}, {$set: {status: PeriodStatusType.QUANTIFY}});
 
   const periodDetailsDto = await findPeriodDetailsDto(periodId);
   res.status(StatusCodes.OK).json(periodDetailsDto);

--- a/packages/api/src/period/utils.ts
+++ b/packages/api/src/period/utils.ts
@@ -213,3 +213,24 @@ export const verifyAnyPraiseAssigned = async (
 
   return some(praisesAssigned);
 };
+
+
+/**
+ * Does period have the latest endDate of all periods?
+ * @param period
+ * @returns
+ */
+export const isPeriodLatest = async (period: PeriodDocument): Promise<boolean> => {
+  const latestPeriod = await PeriodModel.findOne(
+    {},
+    {
+      limit: 1,
+      sort: { endDate: -1 },
+    }
+  );
+
+  if (!latestPeriod) return true;
+  if (latestPeriod._id.toString() === period._id.toString()) return true;
+
+  return false;
+}

--- a/packages/api/src/period/utils.ts
+++ b/packages/api/src/period/utils.ts
@@ -214,13 +214,14 @@ export const verifyAnyPraiseAssigned = async (
   return some(praisesAssigned);
 };
 
-
 /**
  * Does period have the latest endDate of all periods?
  * @param period
  * @returns
  */
-export const isPeriodLatest = async (period: PeriodDocument): Promise<boolean> => {
+export const isPeriodLatest = async (
+  period: PeriodDocument
+): Promise<boolean> => {
   const latestPeriod = await PeriodModel.findOne(
     {},
     {
@@ -233,4 +234,4 @@ export const isPeriodLatest = async (period: PeriodDocument): Promise<boolean> =
   if (latestPeriod._id.toString() === period._id.toString()) return true;
 
   return false;
-}
+};

--- a/packages/api/src/period/validators.ts
+++ b/packages/api/src/period/validators.ts
@@ -1,7 +1,6 @@
 import { add } from 'date-fns';
-import { PeriodModel } from './entities';
 import { getPreviousPeriodEndDate } from './utils';
-import { PeriodDocument, PeriodStatusType } from './types';
+import { PeriodDocument } from './types';
 
 /**
  * Validate period endDate is 7+ days after the previous period's endDate

--- a/packages/api/src/period/validators.ts
+++ b/packages/api/src/period/validators.ts
@@ -1,7 +1,7 @@
 import { add } from 'date-fns';
 import { PeriodModel } from './entities';
 import { getPreviousPeriodEndDate } from './utils';
-import { PeriodDocument } from './types';
+import { PeriodDocument, PeriodStatusType } from './types';
 
 /**
  * Validate period endDate is 7+ days after the previous period's endDate
@@ -21,50 +21,9 @@ async function validatePeriodEndDate7DaysLater(
   return false;
 }
 
-/**
- * Validate period has the latest endDate of all periods
- * @param this
- * @returns
- */
-async function validatePeriodIsLatest(this: PeriodDocument): Promise<boolean> {
-  if (this.isNew) return true;
-
-  const latestPeriod = await PeriodModel.findOne(
-    {},
-    {
-      limit: 1,
-      sort: { endDate: -1 },
-    }
-  );
-
-  if (!latestPeriod) return true;
-  if (latestPeriod._id.toString() === this._id.toString()) return true;
-
-  return false;
-}
-
-/**
- * Validate period status is OPEN
- * @param this
- * @returns
- */
-function validatePeriodIsOpen(this: PeriodDocument): boolean {
-  if (this.status === 'OPEN') return true;
-
-  return false;
-}
-
 export const endDateValidators = [
   {
     validator: validatePeriodEndDate7DaysLater,
     msg: 'Must be minimum 7 days later than previous period.',
-  },
-  {
-    validator: validatePeriodIsLatest,
-    msg: 'Date change only allowed on last period.',
-  },
-  {
-    validator: validatePeriodIsOpen,
-    msg: 'Date change only allowed on open periods.',
   },
 ];


### PR DESCRIPTION
Resolves #259 

The issue is caused by a mongoose validation error being improperly thrown due to changes from #241. (not related to timezone handling, nor the implicit relation of praise - date range). 

Running assignQuantifiers in v0.0.3 once should put the data in the following "dirty" state:
- Quantifiers *are* assigned properly for that period
- But the status of that period is 'OPEN', when it should be 'QUANTIFY'

However, reviewing the production database:
- There is only one period open with the status 'QUANTIFY'
- There are no praise created after that period's endDate with quantifications assigned (i.e. no results to the following query `db.praises.find({createdAt: {$gt: ISODate("2021-12-26T23:59:59.999Z")}, quantifications: {$not: {$size: 0}}})`)

I believe the production data is in a clean state and after this fix we should be able to assign quantifiers properly.


