### PR TITLE
fix: center "Total praise score" column header

### DIFF
--- a/packages/frontend/src/pages/Periods/Details/components/ReceiverTable.tsx
+++ b/packages/frontend/src/pages/Periods/Details/components/ReceiverTable.tsx
@@ -21,18 +21,19 @@ const ReceiverTable = (): JSX.Element | null => {
         {
           Header: 'Receiver',
           accessor: '_id',
+          className: 'text-left',
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           Cell: (data: any): JSX.Element => (
             <UserCell userId={data.row.original.userAccount.name} />
           ),
         },
         {
-          Header: 'Number of praise',
+          Header: 'Praise count',
           className: 'text-center',
           accessor: 'praiseCount',
         },
         {
-          Header: 'Total praise score',
+          Header: 'Praise score',
           className: 'text-center',
           accessor: 'score',
           sortType: 'basic',
@@ -87,7 +88,10 @@ const ReceiverTable = (): JSX.Element | null => {
             <tr {...headerGroup.getHeaderGroupProps()}>
               {headerGroup.headers.map((column) => (
                 // eslint-disable-next-line react/jsx-key
-                <th className="text-left" {...column.getHeaderProps()}>
+                <th
+                  className={(column as any).className}
+                  {...column.getHeaderProps()}
+                >
                   {column.render('Header')}
                 </th>
               ))}


### PR DESCRIPTION
resolves #202 

This Pr changes the names of the headers to better accommodate them, and center aligns them
![Screenshot 2022-04-10 at 5 21 59 AM](https://user-images.githubusercontent.com/62864373/162595499-c3dcd04d-8bf2-4b72-bce8-bafc674363ee.png)
![Screenshot 2022-04-10 at 5 21 48 AM](https://user-images.githubusercontent.com/62864373/162595501-22a9d0f9-d584-4bff-96a4-b069375ad7d8.png)

