### PR TITLE
Fix/262/period selectmenu error

### DIFF
--- a/packages/discord-bot/src/handlers/announce.ts
+++ b/packages/discord-bot/src/handlers/announce.ts
@@ -66,6 +66,13 @@ export const announcementHandler = async (
             selectedUserType === 'UNFINISHED-QUANTIFIERS'
           ) {
             const openPeriods = await PeriodModel.find({ status: 'QUANTIFY' });
+            if (!openPeriods.length) {
+              await interaction.editReply({
+                content: 'No periods open for quantification.',
+                components: [],
+              });
+              return;
+            }
             await interaction.editReply({
               content: 'Which period are you referring to?',
               components: [


### PR DESCRIPTION
fixes #262 

The `/admin announce` command errors out for the "All assigned quantifiers" and "All unfinished quantifiers" options because the bot didn't account for a case when there are no periods with the `QUANTIFY` state.

This PR adds a fix for this condition. (Though, maybe we need an up[date to this text...)