### PR TITLE
fix default logo setting

### DIFF
--- a/packages/api/src/database/migrations/00_initial_settings.ts
+++ b/packages/api/src/database/migrations/00_initial_settings.ts
@@ -103,7 +103,7 @@ const settings = [
   },
   {
     key: 'LOGO',
-    value: '/uploads/praise_logo.png',
+    value: 'uploads/praise_logo.png',
     type: 'Image',
   },
 ];


### PR DESCRIPTION
Fix default value of 'LOGO' setting in migration `00_initial_settings.ts`.

Now the logo will appear properly after running migrations