### PR TITLE
fix(frontend): load period settings when rendering period-specific pages

### DIFF
--- a/packages/frontend/src/pages/Periods/ReceiverSummary/ReceiverSummaryPage.tsx
+++ b/packages/frontend/src/pages/Periods/ReceiverSummary/ReceiverSummaryPage.tsx
@@ -1,5 +1,6 @@
 import BreadCrumb from '@/components/BreadCrumb';
 import { PeriodAndReceiverPageParams, SinglePeriod } from '@/model/periods';
+import { useAllPeriodSettingsQuery } from '@/model/periodsettings';
 import BackLink from '@/navigation/BackLink';
 import { faCalendarAlt } from '@fortawesome/free-solid-svg-icons';
 import {
@@ -38,6 +39,7 @@ const PeriodReceiverMessage = (): JSX.Element | null => {
 
 const QuantSummaryPeriodReceiverPage = (): JSX.Element => {
   const { periodId } = useParams<PeriodAndReceiverPageParams>();
+  useAllPeriodSettingsQuery(periodId);
 
   return (
     <>

--- a/packages/frontend/src/pages/QuantifyPeriod/QuantifyPeriodPage.tsx
+++ b/packages/frontend/src/pages/QuantifyPeriod/QuantifyPeriodPage.tsx
@@ -4,6 +4,7 @@ import {
   PeriodQuantifierReceivers,
   SinglePeriod,
 } from '@/model/periods';
+import { useAllPeriodSettingsQuery } from '@/model/periodsettings';
 import BackLink from '@/navigation/BackLink';
 import { getQuantificationStats } from '@/utils/periods';
 import { faCalendarAlt } from '@fortawesome/free-solid-svg-icons';
@@ -15,7 +16,7 @@ import QuantifyPeriodTable from './components/QuantifyPeriodTable';
 const PeriodMessage = (): JSX.Element => {
   const { periodId } = useParams<PeriodPageParams>();
   const period = useRecoilValue(SinglePeriod(periodId));
-
+  useAllPeriodSettingsQuery(periodId);
   const quantificationStats = getQuantificationStats(
     useRecoilValue(PeriodQuantifierReceivers(periodId))
   );

--- a/packages/frontend/src/pages/QuantifyPeriodReceiver/QuantifyPeriodReceiverPage.tsx
+++ b/packages/frontend/src/pages/QuantifyPeriodReceiver/QuantifyPeriodReceiverPage.tsx
@@ -7,7 +7,10 @@ import {
   SinglePeriod,
   usePeriodQuantifierPraiseQuery,
 } from '@/model/periods';
-import { usePeriodSettingValueRealized } from '@/model/periodsettings';
+import {
+  usePeriodSettingValueRealized,
+  useAllPeriodSettingsQuery,
+} from '@/model/periodsettings';
 import BackLink from '@/navigation/BackLink';
 import { getQuantificationReceiverStats } from '@/utils/periods';
 import {
@@ -40,6 +43,7 @@ const PeriodMessage = (): JSX.Element | null => {
   const { periodId, receiverId } = useParams<PeriodAndReceiverPageParams>();
   const { location } = useHistory();
   usePeriodQuantifierPraiseQuery(periodId, location.key);
+  useAllPeriodSettingsQuery(periodId);
   const usePseudonyms = usePeriodSettingValueRealized(
     periodId,
     'PRAISE_QUANTIFY_RECEIVER_PSEUDONYMS'


### PR DESCRIPTION
Fix issue where quantifier slider breaks when loading quantification page directly.

Ensures that per-period settings have been fetched -- on every page that currently uses them.