### PR TITLE
Fix/praise detail rendering

### DIFF
--- a/packages/frontend/src/pages/Periods/ReceiverSummary/ReceiverSummaryPage.tsx
+++ b/packages/frontend/src/pages/Periods/ReceiverSummary/ReceiverSummaryPage.tsx
@@ -28,14 +28,14 @@ const PeriodReceiverMessage = (): JSX.Element | null => {
   if (!receiver || !receiver.userAccount) return null;
 
   return (
-    <>
+    <div className="praise-box">
       <h2>{receiver.userAccount.name}</h2>
       <div className="mt-5">
         Period: {periodDetails.name}
         <br />
         Total Score: {receiver.scoreRealized}
       </div>
-    </>
+    </div>
   );
 };
 
@@ -48,17 +48,13 @@ const QuantSummaryPeriodReceiverPage = (): JSX.Element => {
       <BreadCrumb name={'Receiver summary for period'} icon={faCalendarAlt} />
       <BackLink to={`/period/${periodId}`} />
 
-      <div className="praise-box">
-        <React.Suspense fallback="Loading…">
-          <PeriodReceiverMessage />
-        </React.Suspense>
-      </div>
+      <React.Suspense fallback="Loading…">
+        <PeriodReceiverMessage />
+      </React.Suspense>
 
-      <div className="praise-box">
-        <React.Suspense fallback="Loading…">
-          <ReceiverSummaryTable />
-        </React.Suspense>
-      </div>
+      <React.Suspense fallback="Loading…">
+        <ReceiverSummaryTable />
+      </React.Suspense>
     </>
   );
 };

--- a/packages/frontend/src/pages/Periods/ReceiverSummary/components/ReceiverSummaryTable.tsx
+++ b/packages/frontend/src/pages/Periods/ReceiverSummary/components/ReceiverSummaryTable.tsx
@@ -54,7 +54,7 @@ const PeriodReceiverTable = (): JSX.Element | null => {
 
   if (!praiseList) return null;
   return (
-    <div>
+    <div className="praise-box">
       {praiseList?.map((praise) => (
         <PraiseRow praise={praise} key={praise?._id} />
       ))}

--- a/packages/frontend/src/pages/PraiseDetails/PraiseDetailsPage.tsx
+++ b/packages/frontend/src/pages/PraiseDetails/PraiseDetailsPage.tsx
@@ -3,56 +3,15 @@ import { HasRole, ROLE_ADMIN } from '@/model/auth';
 import { SinglePeriodByDate } from '@/model/periods';
 import { PraisePageParams, useSinglePraiseQuery } from '@/model/praise';
 import BackLink from '@/navigation/BackLink';
-import { localizeAndFormatIsoDate, DATE_FORMAT_LONG } from '@/utils/date';
 import { faCalendarAlt } from '@fortawesome/free-solid-svg-icons';
 import React from 'react';
 import { useParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import PraiseDetailTable from './components/PraiseDetailTable';
-import getMarkdownText from '@/components/MarkdownText';
-import { PraiseDetailsDto } from 'api/dist/praise/types';
-import { PeriodDetailsDto } from 'api/dist/period/types';
 
-interface Params {
-  period?: PeriodDetailsDto;
-  praise?: PraiseDetailsDto;
-}
+import Praise from '@/components/praise/Praise';
 
-const PeriodReceiverMessage = ({
-  period,
-  praise,
-}: Params): JSX.Element | null => {
-  const isAdmin = useRecoilValue(HasRole(ROLE_ADMIN));
-
-  if (!praise || !period) return null;
-
-  return (
-    <>
-      <div className="text-gray-500">
-        {localizeAndFormatIsoDate(praise.createdAt, DATE_FORMAT_LONG)}
-      </div>
-      <h2>
-        {praise.giver.name} <span className="font-normal">to</span>{' '}
-        {praise.receiver.name}
-      </h2>
-      <div
-        className="mt-2"
-        dangerouslySetInnerHTML={{
-          __html: getMarkdownText(praise.reason),
-        }}
-      ></div>
-      <div className="mt-2">
-        Id: {praise._id}
-        {praise.forwarder && <div>Forwarded by: {praise.forwarder.name}</div>}
-        {period && (period.status === 'CLOSED' || isAdmin) ? (
-          <div>Score: {praise.scoreRealized}</div>
-        ) : null}
-      </div>
-    </>
-  );
-};
-
-const PraiseDetailsPage = (): JSX.Element => {
+const PraiseDetailsPage = (): JSX.Element | null => {
   const { praiseId } = useParams<PraisePageParams>();
   const praise = useSinglePraiseQuery(praiseId);
   const period = useRecoilValue(SinglePeriodByDate(praise?.createdAt));
@@ -61,16 +20,23 @@ const PraiseDetailsPage = (): JSX.Element => {
       ? `/period/${period?._id}/receiver/${praise?.receiver._id}`
       : '/';
 
+  const isAdmin = useRecoilValue(HasRole(ROLE_ADMIN));
+
+  if (!praise) return null;
+
   return (
     <div className="max-w-2xl mx-auto">
       <BreadCrumb name={'Praise details'} icon={faCalendarAlt} />
       <BackLink to={backLinkUrl} />
 
-      <div className="praise-box">
-        <React.Suspense fallback="Loading…">
-          <PeriodReceiverMessage praise={praise} period={period} />
-        </React.Suspense>
-      </div>
+      <React.Suspense fallback="Loading…">
+        <div className="praise-box">
+          <Praise praise={praise} />
+          {period && (period.status === 'CLOSED' || isAdmin) ? (
+            <div>Score: {praise.scoreRealized}</div>
+          ) : null}
+        </div>
+      </React.Suspense>
 
       <div className="praise-box">
         <React.Suspense fallback="Loading…">


### PR DESCRIPTION
**Overview**
- resolves #344 
- Refactor PraiseDetailsPage to use standard Praise component
- Move 'praise-box' div within components, so empty box is never displayed in ReceiverSummaryPage