### PR TITLE
Quantifiers displayed as not being done when they in fact are done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add giver and receiver id to exported praise csv #364
+- Increased precision in calculation of duplicate praise score, from 0 to 2 decimals #342
+
 ### Fixed
 
-### Added
+- Quantifiers displayed as not being done when they in fact are done #349
 
 ## [0.5.0] - 2022-05-02
 

--- a/packages/api/src/period/types.ts
+++ b/packages/api/src/period/types.ts
@@ -2,6 +2,7 @@ import {
   Quantifier,
   QuantificationDocument,
   QuantificationDto,
+  Quantification,
 } from '@praise/types';
 import { Query } from '@shared/types';
 import { UserAccountDocument, UserAccountDto } from '@useraccount/types';
@@ -50,6 +51,12 @@ export interface PeriodDetailsReceiverDto {
   quantifications?: Array<Array<QuantificationDto>>;
   scoreRealized: number;
   userAccount?: UserAccountDto;
+}
+
+export interface PeriodDetailsQuantifier {
+  _id: string;
+  quantifications: Array<Quantification>;
+  praiseCount: number;
 }
 
 export interface PeriodDetailsQuantifierDto {

--- a/packages/api/src/period/utils.ts
+++ b/packages/api/src/period/utils.ts
@@ -59,17 +59,14 @@ const quantifiersWithCounts = (
   quantifiers: PeriodDetailsQuantifier[]
 ): PeriodDetailsQuantifierDto[] => {
   const quantifiersWithQuantificationCounts = quantifiers.map((q) => {
-    let finishedCount = 0;
-    q.quantifications.forEach((quantification) => {
-      finishedCount = isQuantificationCompleted(quantification)
-        ? finishedCount + 1
-        : finishedCount;
-    });
+    const finishedQuantifications = q.quantifications.filter((quantification) =>
+      isQuantificationCompleted(quantification)
+    );
 
     return {
       _id: q._id,
       praiseCount: q.praiseCount,
-      finishedCount,
+      finishedCount: finishedQuantifications.length,
     };
   });
 

--- a/packages/api/src/period/utils.ts
+++ b/packages/api/src/period/utils.ts
@@ -59,14 +59,14 @@ const quantifiersWithCounts = (
   quantifiers: PeriodDetailsQuantifier[]
 ): PeriodDetailsQuantifierDto[] => {
   const quantifiersWithQuantificationCounts = quantifiers.map((q) => {
-    const finishedQuantifications = q.quantifications.filter((quantification) =>
+    const finishedCount = q.quantifications.filter((quantification) =>
       isQuantificationCompleted(quantification)
-    );
+    ).length;
 
     return {
       _id: q._id,
       praiseCount: q.praiseCount,
-      finishedCount: finishedQuantifications.length,
+      finishedCount,
     };
   });
 

--- a/packages/frontend/src/pages/Periods/Details/PeriodDetailsPage.tsx
+++ b/packages/frontend/src/pages/Periods/Details/PeriodDetailsPage.tsx
@@ -75,6 +75,8 @@ const PeriodDetailPage = (): JSX.Element => {
   const [detailsLoaded, setDetailsLoaded] = React.useState<boolean>(false);
   const { path, url } = useRouteMatch();
 
+  PeriodDetailLoader();
+
   React.useEffect(() => {
     if (period?.receivers) {
       setDetailsLoaded(true);

--- a/packages/frontend/src/pages/Periods/Details/PeriodDetailsPage.tsx
+++ b/packages/frontend/src/pages/Periods/Details/PeriodDetailsPage.tsx
@@ -32,13 +32,6 @@ import QuantifierTable from './components/QuantifierTable';
 import ReceiverTable from './components/ReceiverTable';
 import PeriodSettingsForm from './components/PeriodSettingsForm';
 
-const PeriodDetailLoader = (): null => {
-  const { periodId } = useParams<PeriodPageParams>();
-  const { location } = useHistory();
-  useSinglePeriodQuery(periodId, location.key);
-  return null;
-};
-
 const PeriodDetailHead = (): JSX.Element => {
   const { periodId } = useParams<PeriodPageParams>();
   const isAdmin = useRecoilValue(HasRole(ROLE_ADMIN));

--- a/packages/frontend/src/pages/Periods/Details/PeriodDetailsPage.tsx
+++ b/packages/frontend/src/pages/Periods/Details/PeriodDetailsPage.tsx
@@ -68,22 +68,16 @@ const PeriodDetailHead = (): JSX.Element => {
   );
 };
 
-const PeriodDetailPage = (): JSX.Element => {
+const PeriodDetailPage = (): JSX.Element | null => {
   const { periodId } = useParams<PeriodPageParams>();
   const period = useRecoilValue(SinglePeriod(periodId));
   const isAdmin = useRecoilValue(HasRole(ROLE_ADMIN));
-  const [detailsLoaded, setDetailsLoaded] = React.useState<boolean>(false);
   const { path, url } = useRouteMatch();
+  const { location } = useHistory();
 
-  PeriodDetailLoader();
+  useSinglePeriodQuery(periodId, location.key);
 
-  React.useEffect(() => {
-    if (period?.receivers) {
-      setDetailsLoaded(true);
-    }
-  }, [period]);
-
-  if (!detailsLoaded || !period) return <PeriodDetailLoader />;
+  if (!period || !period.receivers) return null;
 
   return (
     <div className="max-w-2xl mx-auto">


### PR DESCRIPTION
Resolves #256 

- Praise details page:
    - moved quantifications count logic for each quantifier in period from mongo query to utils method
    - used `isQuantificationCompleted()` to count completed quantifications 
    - fix to load quantifier finished items without need to reload the screen