### PR TITLE
Fix/activate useraccount only once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Quantifiers displayed as not being done when they in fact are done #349
 - UI issue: checkbox unchecked when praise score changes #354
+- Responds with an error message if the user tries to activate their account via the discord bot, and it has already been activated. #357 #362
 
 ## [0.5.0] - 2022-05-02
 

--- a/packages/api/src/database/migrations/06_already_activated_setting.ts
+++ b/packages/api/src/database/migrations/06_already_activated_setting.ts
@@ -1,0 +1,33 @@
+import { SettingsModel } from '../../settings/entities';
+
+const settings = [
+  {
+    key: 'PRAISE_ACCOUNT_ALREADY_ACTIVATED_ERROR',
+    value:
+      '**❌ Account Already Activated**\nYour account is already activated in the praise system.',
+    type: 'Textarea',
+    label: 'Praise Account Already Activated',
+    description: 'Discord /activate command response',
+  },
+];
+
+const up = async (): Promise<void> => {
+  const settingUpdates = settings.map((s) => ({
+    updateOne: {
+      filter: { key: s.key },
+
+      // Insert setting if not found, otherwise continue
+      update: { $setOnInsert: { ...s } },
+      upsert: true,
+    },
+  }));
+
+  await SettingsModel.bulkWrite(settingUpdates);
+};
+
+const down = async (): Promise<void> => {
+  const allKeys = settings.map((s) => s.key);
+  await SettingsModel.deleteMany({ key: { $in: allKeys } });
+};
+
+export { up, down };

--- a/packages/discord-bot/src/utils/praiseEmbeds.ts
+++ b/packages/discord-bot/src/utils/praiseEmbeds.ts
@@ -44,6 +44,15 @@ export const notActivatedError = async (): Promise<string> => {
   }
 };
 
+export const alreadyActivatedError = async (): Promise<string> => {
+  const msg = await getSetting('PRAISE_ACCOUNT_ALREADY_ACTIVATED_ERROR');
+  if (msg && typeof msg === 'string') {
+    return msg;
+  } else {
+    return 'PRAISE ACCOUNT ALREADY ACTIVATED (message not set)';
+  }
+};
+
 export const giverNotActivatedError = async (
   praiseGiver: User
 ): Promise<string> => {


### PR DESCRIPTION
Resolves #357 

Responds with an error message if the user tries to activate their account via the discord bot, and it has already been activated.